### PR TITLE
Changes to "Organize your components"

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,32 +168,58 @@ test('it reloads user in promise handler', function(assert) {
 ### Organize your components
 To maintain good readable of code, you should write code grouped and ordered in this way:
 1. Default values
-2. Single line computed properties
-3. Multiline computed properties
-4. Actions
+2. Services
+3. Single line computed properties
+4. Multiline computed properties
+5. Observers
+6. Lifecycle Hooks
+7. Actions
+8. Custom / private methods
 
 ```javascript
-const { Component, computed } = Ember;
+const { Component, computed, inject: { service } } = Ember;
 const { alias } = computed;
 
 export default Component.extend({
   // 1. Defaults
   role: 'sloth',
+  
+  // 2. Services
+  i18n: service(),
 
-  // 2. Single line Computed Property
+  // 3. Single line Computed Property
   vehicle: alias('car'),
 
-  // 3. Multiline Computed Property
+  // 4. Multiline Computed Property
   levelOfHappiness: computed('attitude', 'health', function() {
     const result = this.get('attitude') * this.get('health') * Math.random();
     return result;
   }),
 
-  // 4. All actions
+  // 5. Observers
+  onVahicleChange: observer('vehicle', function() {
+    // observer logic
+  }),
+
+  // 6. Lifecycle Hooks
+  init() {
+    // custom init logic
+  },
+
+  didInsertElement() {
+    // custom didInsertElement logic
+  },
+
+  // 7. All actions
   actions: {
     sneakyAction() {
       return this._secretMethod();
     }
+  },
+
+  // 8. Custom / private methods
+  _secretMethod() {
+    // custom secret method logic
   }
 });
 ```

--- a/README.md
+++ b/README.md
@@ -167,8 +167,8 @@ test('it reloads user in promise handler', function(assert) {
 
 ### Organize your components
 To maintain good readable of code, you should write code grouped and ordered in this way:
-1. Default values
-2. Services
+1. Services
+2. Default values
 3. Single line computed properties
 4. Multiline computed properties
 5. Observers
@@ -181,11 +181,11 @@ const { Component, computed, inject: { service } } = Ember;
 const { alias } = computed;
 
 export default Component.extend({
-  // 1. Defaults
-  role: 'sloth',
-  
-  // 2. Services
+  // 1. Services
   i18n: service(),
+  
+  // 2. Defaults
+  role: 'sloth',
 
   // 3. Single line Computed Property
   vehicle: alias('car'),

--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ When content of each block is larger than one line, use component to wrap this c
 ## Tests
 
 ### Use page objects in acceptance testing
-In acceptance tests there is a tendency to repeat the same code meny times (mainly selectors). It's also hard to reason about exact behavior based only on selector naes. To avoid this we can extract this to other abstract layer and then import them to tests.
+In acceptance tests there is a tendency to repeat the same code many times (mainly selectors). It's also hard to reason about exact behavior based only on selector naes. To avoid this we can extract this to other abstract layer and then import them to tests.
 
 ```javascript
 // GOOD


### PR DESCRIPTION
https://github.com/netguru/eslint-plugin-netguru-ember is pointing to  "Organise your components" for `order-in-components` rule documentation. https://github.com/netguru/eslint-plugin-netguru-ember/pull/4 extends this rule so in order to have consistent documentation here is the proposal for updating the doc so it matches the new ESlint rule code.