### PR TITLE
add new rule - Do not use Ember's function prototype extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,22 @@ test('it reloads user in promise handler', function(assert) {
 });
 ```
 
+### Do not use Ember's `function` prototype extensions
+Use computed property syntax, observer syntax or module hooks instead of `.property()`, `.observe()` or `.on()` in Ember modules.
+```js
+export default Component.extend({
+    // BAD
+    abc: function() { /* custom logic */ }.property('xyz'),
+    def: function() { /* custom logic */ }.observe('xyz'),
+    ghi: function() { /* custom logic */ }.on('didInsertElement'),
+    
+    // GOOD
+    abc: computed('xyz', function() { /* custom logic */ }),
+    def: observer('xyz', function() { /* custom logic */ }),
+    didInsertElement() { * custom logic */ }
+});
+```
+
 ## Organizing
 
 ### Organize your components

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ export default Component.extend({
     // GOOD
     abc: computed('xyz', function() { /* custom logic */ }),
     def: observer('xyz', function() { /* custom logic */ }),
-    didInsertElement() { * custom logic */ }
+    didInsertElement() { /* custom logic */ }
 });
 ```
 


### PR DESCRIPTION
New rule that adds using Ember function prototype extensions like:
- function() {}.property('abc')
- function() {}.observe('abc')
- function() {}.on('init')

to the list of anti-patterns.

Connected with: 
- https://github.com/netguru/eslint-plugin-netguru-ember/pull/17
- https://github.com/netguru/eslint-plugin-netguru-ember/issues/9
