### PR TITLE
add new rule - don't use .on() calls as components values

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,6 +491,18 @@ export default Component.extend({
   }
 })
 ```
+### Don't use `.on()` calls as components values
+Prevents using `.on()` in favour to component lifecycle hooks methods
+```js
+export default Component.extend({
+  // BAD
+  abc: on('didInsertElement', function () { /* custom logic */ }),
+
+  // GOOD
+  didInsertElement() { /* custom logic */ }
+});
+```
+
 ## Routing
 
 ### Route naming


### PR DESCRIPTION
Adding new rule proposed here:: https://github.com/netguru/eslint-plugin-netguru-ember/issues/11

Prevents form using `.on()` calls as property values of Ember components.

Example:
```js
export default Component.extend({
  // BAD
  abc: on('didInsertElement', function () { /* custom logic */ }),

  // GOOD
  didInsertElement() { /* custom logic */ }
});
```

PR with the new linter rule: https://github.com/netguru/eslint-plugin-netguru-ember/pull/18