### PR TITLE
Add section about using Ember.get and Ember.set by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ export default Component.extend({
     abc: function() { /* custom logic */ }.property('xyz'),
     def: function() { /* custom logic */ }.observe('xyz'),
     ghi: function() { /* custom logic */ }.on('didInsertElement'),
-    
+
     // GOOD
     abc: computed('xyz', function() { /* custom logic */ }),
     def: observer('xyz', function() { /* custom logic */ }),
@@ -187,6 +187,8 @@ this.get('fooProperty');
 this.set('fooProperty', 'bar');
 this.getWithDefault('fooProperty', 'defaultProp');
 object.get('fooProperty');
+object.getProperties('foo', 'bar');
+object.setProperties({ foo: 'bar', baz: 'qux' });
 
 // Good
 
@@ -196,6 +198,8 @@ get(this, 'fooProperty');
 set(this, 'fooProperty', 'bar');
 getWithDefault(this, 'fooProperty', 'defaultProp');
 get(object, 'fooProperty');
+getProperties(object, 'foo', 'bar');
+setProperties(object, { foo: 'bar', baz: 'qux' });
 ```
 
 ## Organizing
@@ -218,7 +222,7 @@ const { alias } = computed;
 export default Component.extend({
   // 1. Services
   i18n: service(),
-  
+
   // 2. Defaults
   role: 'sloth',
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,25 @@ export default Component.extend({
 });
 ```
 
+### Use `Ember.get` and `Ember.set`
+This way you don't have to worry whether the object that you're trying to access is an `Ember.Object` or not. It also solves the problem of trying to wrap every object in `Ember.Object` in order to be able to use things like `getWithDefault`.
+```javascript
+// Bad
+this.get('fooProperty');
+this.set('fooProperty', 'bar');
+this.getWithDefault('fooProperty', 'defaultProp');
+object.get('fooProperty');
+
+// Good
+
+const { get, set, getWithDefault } = Ember;
+// ...
+get(this, 'fooProperty');
+set(this, 'fooProperty', 'bar');
+getWithDefault(this, 'fooProperty', 'defaultProp');
+get(object, 'fooProperty');
+```
+
 ## Organizing
 
 ### Organize your components


### PR DESCRIPTION
As agreed on slack and last ember meeting, we should be always using Ember.get and Ember.set -this addition to the styleguide reflects that.