### PR TITLE
Add "avoid leaking state" rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ object.setProperties({ foo: 'bar', baz: 'qux' });
 
 // Good
 
-const { 
+const {
   get,
   set,
   getWithDefault,
@@ -545,6 +545,38 @@ export default Component.extend({
 
   // GOOD
   didInsertElement() { /* custom logic */ }
+});
+```
+### Avoid leaking state
+Don't use arrays and objects as default properties. More info here: https://dockyard.com/blog/2015/09/18/ember-best-practices-avoid-leaking-state-into-factories
+
+
+```
+// BAD
+export default Ember.Component.extend({
+  items: [],
+
+  actions: {
+    addItem(item) {
+      this.get('items').pushObject(item);
+    },
+  },
+});
+```
+
+```
+// Good
+export default Ember.Component.extend({
+  init() {
+    this._super(...arguments);
+    this.items = [];
+  },
+
+  actions: {
+    addItem(item) {
+      this.get('items').pushObject(item);
+    },
+  },
 });
 ```
 


### PR DESCRIPTION
According to this proposal: https://github.com/netguru/eslint-plugin-netguru-ember/issues/8
I created eslint rule: https://github.com/netguru/eslint-plugin-netguru-ember/pull/16

This PR extends our styleguide with rule that we should avoid using arrays and objects as default properties due to leaking data constraints.