### PR TITLE
Add "use-brace-expansion" rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,23 @@ getProperties(object, 'foo', 'bar');
 setProperties(object, { foo: 'bar', baz: 'qux' });
 ```
 
+### Use brace expansion
+This allows much less redundancy and is easier to read.
+
+Note that **the dependent keys must be together (without space)** for the brace expansion to work.
+
+```
+// Good
+fullName: computed('user.{firstName,lastName}', {
+  // Code
+})
+
+// Bad
+fullName: computed('user.firstName', 'user.lastName', {
+  // Code
+})
+```
+
 ## Organizing
 
 ### Organize your components


### PR DESCRIPTION
This PR adds Dockyard's rule "use-brace-expansion".